### PR TITLE
Preserve aspect ratio during conversion.

### DIFF
--- a/src/context.py
+++ b/src/context.py
@@ -170,6 +170,7 @@ class Context:
 
         self.frame_rate = self.video_settings.frame_rate
         self.width, self.height = self.video_settings.width, self.video_settings.height
+        self.dar = self.video_settings.dar
 
         # self.frame_count = ffmpeg.count(frames)
         self.frame_count = self.video_settings.frame_count

--- a/src/wrappers/ffmpeg/ffprobe.py
+++ b/src/wrappers/ffmpeg/ffprobe.py
@@ -34,6 +34,36 @@ def get_video_info(ffprobe_dir, input_video):
     return json.loads(json_str.decode('utf-8'))
 
 
+def get_aspect_ratio(ffprobe_dir, input_video):
+    """ Gets input video information
+    This method reads input video information
+    using ffprobe in dictionary.
+    Arguments:
+        input_video {string} -- input video file path
+    Returns:
+        dictionary -- JSON text of input video information
+    """
+
+    # this execution command needs to be hard-coded
+    # since video2x only strictly recignizes this one format
+    execute = [
+        ffprobe_dir,
+        '-v',
+        'error',
+        '-select_streams',
+        'v:0',
+        '-show_entries',
+        'stream=display_aspect_ratio',
+        '-of',
+        'csv=p=0',
+        input_video
+    ]
+
+    return_bytes = subprocess.run(execute, check=True, stdout=subprocess.PIPE).stdout
+    return_string = return_bytes.decode("utf-8")
+
+    return return_string
+
 def get_width_height(ffprobe_dir, input_video):
     """ Gets input video information
     This method reads input video information

--- a/src/wrappers/ffmpeg/pipe.py
+++ b/src/wrappers/ffmpeg/pipe.py
@@ -35,6 +35,7 @@ class Pipe():
 
         self.nosound_file = output_no_sound
         self.frame_rate = str(self.context.frame_rate)
+        self.dar = self.context.dar
         self.input_file = self.context.input_file
         self.output_file = self.context.output_file
         self.ffmpeg_dir = self.context.ffmpeg_dir
@@ -50,6 +51,11 @@ class Pipe():
 
         self.ffmpeg_pipe_command.append("-r")
         self.ffmpeg_pipe_command.append(self.frame_rate)
+
+        if self.dar:
+            self.ffmpeg_pipe_command.append("-vf")
+            self.ffmpeg_pipe_command.append("setdar=" + self.dar.replace(":", "/"))
+
         self.ffmpeg_pipe_command.append(self.nosound_file)
 
         self.ffmpeg_pipe_subprocess = None

--- a/src/wrappers/ffmpeg/videosettings.py
+++ b/src/wrappers/ffmpeg/videosettings.py
@@ -1,6 +1,6 @@
 from fractions import Fraction
 
-from wrappers.ffmpeg.ffprobe import get_video_info, get_width_height, get_frame_rate, get_frame_count
+from wrappers.ffmpeg.ffprobe import get_video_info, get_width_height, get_frame_rate, get_frame_count, get_aspect_ratio
 
 
 # A simple way to just have a class w/ the contents we need to operate dandere2x
@@ -23,7 +23,9 @@ class VideoSettings:
             self.height = self.settings_json['streams'][0]['height']
             self.width = self.settings_json['streams'][0]['width']
             self.frame_rate = float(Fraction(self.settings_json['streams'][0]['r_frame_rate']))
+            self.dar = self.settings_json['streams'][0]['display_aspect_ratio']
 
         except KeyError:
             self.height, self.width = get_width_height(self.ffprobe_dir, video_file)
             self.frame_rate = float(Fraction(get_frame_rate(self.ffprobe_dir, video_file)))
+            self.dar = get_aspect_ratio(self.ffprobe_dir, video_file)


### PR DESCRIPTION
This PR preserves the aspect ratio of the video by reading the display aspect ratio from the original file and setting it on the resulting video file. This prevents the aspect ratio from being changed if a resize is needed (due to block size mismatch) or if the original file had a display aspect ratio that didn't match the file's native resolution.