### PR TITLE
Use avg_frame_rate for frame rate calculation

### DIFF
--- a/src/wrappers/ffmpeg/ffprobe.py
+++ b/src/wrappers/ffmpeg/ffprobe.py
@@ -116,7 +116,7 @@ def get_frame_rate(ffprobe_dir, input_video):
         '-select_streams',
         'v:0',
         '-show_entries',
-        'stream=r_frame_rate',
+        'stream=avg_frame_rate',
         '-of',
         'csv=p=0',
         input_video

--- a/src/wrappers/ffmpeg/videosettings.py
+++ b/src/wrappers/ffmpeg/videosettings.py
@@ -22,7 +22,7 @@ class VideoSettings:
         try:
             self.height = self.settings_json['streams'][0]['height']
             self.width = self.settings_json['streams'][0]['width']
-            self.frame_rate = float(Fraction(self.settings_json['streams'][0]['r_frame_rate']))
+            self.frame_rate = float(Fraction(self.settings_json['streams'][0]['avg_frame_rate']))
             self.dar = self.settings_json['streams'][0]['display_aspect_ratio']
 
         except KeyError:


### PR DESCRIPTION
From time to time the r_frame_rate would report wrong overall video FPS if frame ticks would not be constant, I have switched this to avg_frame_rate which should instead represent the actual average frame rate of the whole video accounting for longer/shorter ticks.

I assume that this should work just fine for all videos as it did before while also supporting videos where the frame rate is not exactly constant, I've tried this with some of my videos and with the yn_moving_480.mkv.